### PR TITLE
Allow root relative path to append

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ const visit = require("unist-util-visit")
 
 module.exports = function (options) {
   function visitor(node) {
-    node.url = new URL(node.url.replace(/^\//, ""), options.absolutePath).href
+    // Sanitize URL by removing leading `/`
+    const relativeUrl = node.url.replace(/^\//, "")
+    
+    node.url = new URL(relativeUrl, options.absolutePath).href
   }
 
   function transform(tree) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const visit = require("unist-util-visit")
 
 module.exports = function (options) {
   function visitor(node) {
-    node.url = new URL(node.url, options.absolutePath).href
+    node.url = new URL(node.url.replace(/^\//, ""), options.absolutePath).href
   }
 
   function transform(tree) {

--- a/test.js
+++ b/test.js
@@ -13,6 +13,14 @@ test("remark-img-links", async function (t) {
       const expectedYield = '<p><img src="https://cdn.domain.com/images/screenshot.png" alt="Screenshot"></p>\n'
       t.equal(String(file), expectedYield)
     })
+  
+  remark()
+    .use(imgLinks, { absolutePath: "https://cdn.domain.com/assets/" })
+    .use(html)
+    .process("![Screenshot](/images/screenshot.png)", (err, file) => {
+      const expectedYield = '<p><img src="https://cdn.domain.com/assets/images/screenshot.png" alt="Screenshot"></p>\n'
+      t.equal(String(file), expectedYield)
+    })
 
   remark()
     .use(imgLinks, { absolutePath: "https://cdn.domain.com/" })

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const html = require("remark-html")
 const imgLinks = require(".")
 
 test("remark-img-links", async function (t) {
-  t.plan(3)
+  t.plan(4)
 
   remark()
     .use(imgLinks, { absolutePath: "https://cdn.domain.com/" })


### PR DESCRIPTION
A root relative path like `/image/1` will override the existing path on `https://example.com/assets/` and result in `https://example.com/image/1` when it makes more sense to be `https://example.com/assets/image/1`.